### PR TITLE
hotfix/avoid-dropping-DB-when-deploying

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -12,7 +12,10 @@ bundle exec rake assets:precompile
 bundle exec rake assets:clean
 
 # Drop, create, and migrate the database
-bundle exec rails db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-bundle exec rails db:create
-bundle exec rails db:schema:load
+# bundle exec rails db:drop DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+# bundle exec rails db:create
+# bundle exec rails db:schema:load
+# bundle exec rails db:migrate
+
+# Only run migrations without dropping the database
 bundle exec rails db:migrate


### PR DESCRIPTION
## In this PR, I've:
- Created a `hotfix/avoid-dropping-DB-when-deploying` branch
- Avoid dropping DB when deploying another web app that shares the same DB that this web app